### PR TITLE
Fix signal forwarding in container, use go packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV ETCD_URL http://172.17.42.1:4001
 ENV PORT 80
 ENV PATH /
 
-CMD /etcdenv -n ${NAMESPACE} -s http://172.17.42.1:4001 -w VULCAND_URL \
+CMD exec /etcdenv -n ${NAMESPACE} -s http://172.17.42.1:4001 -w VULCAND_URL \
   /vulcand-healthcheck -port ${PORT} -path ${PATH} \
   -backend-id ${BACKEND_ID} -server-id ${SERVER_ID} \
   -private-ip ${PRIVATE_IP}

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -1,4 +1,4 @@
-package main
+package healthcheck
 
 import (
 	"fmt"

--- a/main.go
+++ b/main.go
@@ -7,6 +7,10 @@ import (
 	"os"
 	"os/signal"
 	"time"
+
+	"github.com/upfluence/vulcand-healthcheck/healthcheck"
+	"github.com/upfluence/vulcand-healthcheck/registry"
+	"github.com/upfluence/vulcand-healthcheck/watcher"
 )
 
 const currentVersion = "0.0.1"
@@ -80,7 +84,7 @@ func main() {
 		vulcandURL = v
 	}
 
-	registry := NewRegistry(
+	registry := registry.NewRegistry(
 		vulcandURL,
 		flags.BackendID,
 		flags.ServerID,
@@ -89,7 +93,7 @@ func main() {
 		flags.Interval+flags.Timeout,
 	)
 
-	healthCheck := NewHealthCheck(
+	healthCheck := healthcheck.NewHealthCheck(
 		flags.PrivateIP,
 		flags.Port,
 		flags.Path,
@@ -97,11 +101,11 @@ func main() {
 	)
 
 	sig := make(chan os.Signal)
-	signal.Notify(sig, os.Kill, os.Interrupt)
+	signal.Notify(sig, os.Interrupt)
 
 	stopChan := make(chan bool)
 
-	watcher := NewWatcher(
+	watcher := watcher.NewWatcher(
 		healthCheck,
 		registry,
 		flags.Interval,

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,4 +1,4 @@
-package main
+package registry
 
 import (
 	"fmt"

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -1,25 +1,28 @@
-package main
+package watcher
 
 import (
 	"log"
 	"time"
+
+	"github.com/upfluence/vulcand-healthcheck/healthcheck"
+	"github.com/upfluence/vulcand-healthcheck/registry"
 )
 
 type Watcher struct {
-	registry           *Registry
-	healthCheck        *HealthCheck
+	registry           *registry.Registry
+	healthCheck        *healthcheck.HealthCheck
 	interval           time.Duration
 	stopChan           chan bool
 	healthyThreshold   uint
 	unhealthyThreshold uint
 
-	history      []Status
+	history      []healthcheck.Status
 	isRegistered bool
 }
 
 func NewWatcher(
-	healthCheck *HealthCheck,
-	registry *Registry,
+	healthCheck *healthcheck.HealthCheck,
+	registry *registry.Registry,
 	interval time.Duration,
 	healthyThreshold, unhealthyThreshold uint,
 	stopChan chan bool) *Watcher {
@@ -30,7 +33,7 @@ func NewWatcher(
 		stopChan,
 		healthyThreshold,
 		unhealthyThreshold,
-		[]Status{},
+		[]healthcheck.Status{},
 		false,
 	}
 }
@@ -43,7 +46,7 @@ func (w *Watcher) Watch() {
 
 			r := w.healthCheck.Ping()
 
-			if r == Healthy {
+			if r == healthcheck.Healthy {
 				log.Println("The service is healthy")
 			} else {
 				log.Println("The service is not healthy")
@@ -90,7 +93,7 @@ func (w *Watcher) shouldRegisterServer() bool {
 	}
 
 	for _, status := range w.history {
-		if status == Unhealthy {
+		if status == healthcheck.Unhealthy {
 			return false
 		}
 	}
@@ -104,7 +107,7 @@ func (w *Watcher) shouldDeleteServer() bool {
 	}
 
 	for _, status := range w.history {
-		if status == Healthy {
+		if status == healthcheck.Healthy {
 			return false
 		}
 	}


### PR DESCRIPTION
Using shell style CMD declaration in dockerfile actually does not instanciate process as container pid 1 and does break signal forwarding.

Calling exec fixes the issue.
